### PR TITLE
add .env to .gitignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -30,6 +30,7 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
also regen keys (AWS API gateway being public is fine as long as you have proper access control)

if you already changed api keys after leaking them, this pr can be ignored